### PR TITLE
Clear timeout after execution

### DIFF
--- a/lib/invoke.js
+++ b/lib/invoke.js
@@ -35,7 +35,7 @@ module.exports = function (eventObj, path, handler, timeout, callback) {
 	var context = require('./context.js');
 
 	var timeoutReached = false;
-	setTimeout(function(){
+	var timer = setTimeout(function(){
 		timeoutReached = true;
 		callback(new Error("Task timed out after " + (timeout / 1000).toFixed(2) + " seconds"));
 	}, timeout); 
@@ -52,4 +52,5 @@ module.exports = function (eventObj, path, handler, timeout, callback) {
 	} else {
 		callback(new Error('Could not find Lambda handler'));
 	}
+	clearTimeout(timer);
 };


### PR DESCRIPTION
As per previous comment, the timer "leaks" when running from within scripts, gulp mocha in my case. By clearing the timout this is prevented.
